### PR TITLE
SIP: Fix missing copy constructor

### DIFF
--- a/sip/ZwoInterface.sip
+++ b/sip/ZwoInterface.sip
@@ -40,6 +40,9 @@ public:
 	virtual void getStatus(StatusType &status /Out/);
 
 	virtual int getNbHwAcquiredFrames();
+
+private:
+	Interface(const Interface&);
 };
 
 };


### PR DESCRIPTION
The sip tool requires a copy constructor for the generated python
interface.